### PR TITLE
Conditionally avoid method calls deprecated in PHP8

### DIFF
--- a/PHPUnit/Util/Class.php
+++ b/PHPUnit/Util/Class.php
@@ -149,24 +149,19 @@ class PHPUnit_Util_Class
             $typeHint  = '';
 
             if (!$forCall) {
-                if ($parameter->isArray()) {
-                    $typeHint = 'array ';
-                }
-
-                else if (version_compare(PHP_VERSION, '5.4', '>') &&
+                if (PHP_VERSION_ID >= 80000 ) {
+                    $typeHint = $parameter->hasType() ? (string)$parameter->getType() : 'mixed';
+                } elseif ($parameter->isArray()) {
+                    $typeHint = 'array';
+                } elseif (version_compare(PHP_VERSION, '5.4', '>') &&
                          $parameter->isCallable()) {
                     $typeHint = 'callable ';
-                }
-
-                else {
+                } else {
                     try {
                         $class = $parameter->getClass();
-                    }
-
-                    catch (ReflectionException $e) {
+                    } catch (ReflectionException $e) {
                         $class = FALSE;
                     }
-
                     if ($class) {
                         $typeHint = $class->getName() . ' ';
                     }

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -196,7 +196,7 @@ class PHPUnit_Util_Configuration
     /**
      * @since  Method available since Release 3.4.0
      */
-    private final function __clone()
+    private function __clone()
     {
     }
 

--- a/Tests/_files/Singleton.php
+++ b/Tests/_files/Singleton.php
@@ -7,7 +7,7 @@ class Singleton
     {
     }
 
-    private final function __clone()
+    private function __clone()
     {
     }
 


### PR DESCRIPTION
This small fix is needed to make the actual framework PHP8 compatible as else you'd be flooded in deprecation messages when running the tests.