### PR TITLE
circular dependency issue after switching to composer v2

### DIFF
--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -197,6 +197,13 @@ class PHPUnit_Util_GlobalState
         if (defined('__PHPUNIT_PHAR__')) {
             $prefix = 'phar://' . __PHPUNIT_PHAR__ . '/';
         }
+        
+        // Do not process bootstrap script - composer v2 compatibility
+        // https://github.com/composer/composer/issues/10387#issuecomment-1002942296
+        // https://github.com/sebastianbergmann/phpunit/pull/4846
+        while (strpos($files[0], 'bin/phpunit') !== false) {
+            array_shift($files);
+        }
 
         for ($i = count($files) - 1; $i > 0; $i--) {
             $file = $files[$i];


### PR DESCRIPTION
when you run `vendor/bin/phpunit` with composer v2, then extra file (`vendor/bin/phpunit`) is being added to the autoloading list for tests with`@runInSeparateProcess` annotation. 

This PR introduce a change removing `**/bin/phpunit` from the list.

[from sebastianbergmann/phpunit#4846](https://github.com/sebastianbergmann/phpunit/pull/4846)
_Composer 2.2 introduces some additional indirection for binaries to allow everyone to use custom PHP versions e.g. php7.4 vendor/bin/phpunit and ensure that vendor/phpunit/phpunit/phpunit is executed with php7.4 always (this previously worked only in cases/platforms where symlinks were supported)._

**References**
https://github.com/composer/composer/issues/10387#issuecomment-1002942296
https://github.com/sebastianbergmann/phpunit/pull/4846

**Workaround**
There is a way to avoid this change. We have to call `vendor/zf1s/phpunit/composer/bin/phpunit` instead of `vendor/bin/phpunit`. I'm not sure if it's a good approach for switching to workaround. It might be confusing for others why there is a memory leak.
