### PR TITLE
fix php 8.* compatibility

### DIFF
--- a/PHPUnit/Extensions/PhptTestCase.php
+++ b/PHPUnit/Extensions/PhptTestCase.php
@@ -106,7 +106,7 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 1;

--- a/PHPUnit/Extensions/RepeatedTest.php
+++ b/PHPUnit/Extensions/RepeatedTest.php
@@ -115,7 +115,7 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->timesRepeat * count($this->test);

--- a/PHPUnit/Extensions/TestDecorator.php
+++ b/PHPUnit/Extensions/TestDecorator.php
@@ -104,7 +104,7 @@ class PHPUnit_Extensions_TestDecorator extends PHPUnit_Framework_Assert implemen
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->test);

--- a/PHPUnit/Framework/Constraint.php
+++ b/PHPUnit/Framework/Constraint.php
@@ -112,7 +112,7 @@ abstract class PHPUnit_Framework_Constraint implements Countable, PHPUnit_Framew
      * @return integer
      * @since  Method available since Release 3.4.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 1;

--- a/PHPUnit/Framework/Constraint/And.php
+++ b/PHPUnit/Framework/Constraint/And.php
@@ -151,7 +151,7 @@ class PHPUnit_Framework_Constraint_And extends PHPUnit_Framework_Constraint
      * @return integer
      * @since  Method available since Release 3.4.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         $count = 0;

--- a/PHPUnit/Framework/Constraint/Composite.php
+++ b/PHPUnit/Framework/Constraint/Composite.php
@@ -107,7 +107,7 @@ abstract class PHPUnit_Framework_Constraint_Composite extends PHPUnit_Framework_
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->innerConstraint);

--- a/PHPUnit/Framework/Constraint/IsAnything.php
+++ b/PHPUnit/Framework/Constraint/IsAnything.php
@@ -95,7 +95,7 @@ class PHPUnit_Framework_Constraint_IsAnything extends PHPUnit_Framework_Constrai
      * @return integer
      * @since  Method available since Release 3.5.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 0;

--- a/PHPUnit/Framework/Constraint/Not.php
+++ b/PHPUnit/Framework/Constraint/Not.php
@@ -196,7 +196,7 @@ class PHPUnit_Framework_Constraint_Not extends PHPUnit_Framework_Constraint
      * @return integer
      * @since  Method available since Release 3.4.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->constraint);

--- a/PHPUnit/Framework/Constraint/Or.php
+++ b/PHPUnit/Framework/Constraint/Or.php
@@ -144,7 +144,7 @@ class PHPUnit_Framework_Constraint_Or extends PHPUnit_Framework_Constraint
      * @return integer
      * @since  Method available since Release 3.4.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         $count = 0;

--- a/PHPUnit/Framework/Constraint/Xor.php
+++ b/PHPUnit/Framework/Constraint/Xor.php
@@ -149,7 +149,7 @@ class PHPUnit_Framework_Constraint_Xor extends PHPUnit_Framework_Constraint
      * @return integer
      * @since  Method available since Release 3.4.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         $count = 0;

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -328,7 +328,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 1;

--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -729,7 +729,7 @@ class PHPUnit_Framework_TestResult implements Countable
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->runTests;

--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -422,7 +422,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         if ($this->numTests > -1) {
@@ -926,7 +926,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      * @return RecursiveIteratorIterator
      * @since  Method available since Release 3.1.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new RecursiveIteratorIterator(

--- a/PHPUnit/Util/TestSuiteIterator.php
+++ b/PHPUnit/Util/TestSuiteIterator.php
@@ -80,7 +80,7 @@ class PHPUnit_Util_TestSuiteIterator implements RecursiveIterator
      * Rewinds the Iterator to the first element.
      *
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
@@ -91,7 +91,7 @@ class PHPUnit_Util_TestSuiteIterator implements RecursiveIterator
      *
      * @return boolean
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->position < count($this->tests);
@@ -102,7 +102,7 @@ class PHPUnit_Util_TestSuiteIterator implements RecursiveIterator
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -113,7 +113,7 @@ class PHPUnit_Util_TestSuiteIterator implements RecursiveIterator
      *
      * @return PHPUnit_Framework_Test
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->valid() ? $this->tests[$this->position] : NULL;
@@ -123,7 +123,7 @@ class PHPUnit_Util_TestSuiteIterator implements RecursiveIterator
      * Moves forward to next element.
      *
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->position++;

--- a/Tests/_files/DoubleTestCase.php
+++ b/Tests/_files/DoubleTestCase.php
@@ -8,7 +8,7 @@ class DoubleTestCase implements PHPUnit_Framework_Test
         $this->testCase = $testCase;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 2;

--- a/Tests/_files/SampleArrayAccess.php
+++ b/Tests/_files/SampleArrayAccess.php
@@ -13,7 +13,7 @@ class SampleArrayAccess implements ArrayAccess
     public function __construct() {
         $this->container = array();
     }
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value) {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -21,15 +21,15 @@ class SampleArrayAccess implements ArrayAccess
             $this->container[$offset] = $value;
         }
     }
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset) {
         return isset($this->container[$offset]);
     }
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset) {
         unset($this->container[$offset]);
     }
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset) {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }

--- a/Tests/_files/TestIterator.php
+++ b/Tests/_files/TestIterator.php
@@ -9,31 +9,31 @@ class TestIterator implements Iterator
         $this->array = $array;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->position < count($this->array);
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->array[$this->position];
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->position++;

--- a/Tests/_files/TestIterator2.php
+++ b/Tests/_files/TestIterator2.php
@@ -8,31 +8,31 @@ class TestIterator2 implements Iterator {
         $this->data = $array;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->data);
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function next()
     {
         next($this->data);
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->data);
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return key($this->data) !== null;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->data);

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "phpunit/php-file-iterator": "^1.4.5",
         "phpunit/php-code-coverage": "^1.2.6",
         "phpunit/php-timer": "1.0.7",
-        "symfony/yaml": "~2.0",
+        "symfony/yaml": "<7",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-json": "*",

--- a/deps/php-file-iterator/src/Iterator.php
+++ b/deps/php-file-iterator/src/Iterator.php
@@ -73,7 +73,7 @@ class File_Iterator extends FilterIterator
     /**
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function accept()
     {
         $current  = $this->getInnerIterator()->current();

--- a/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator/mocked_object_method.tpl.dist
+++ b/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator/mocked_object_method.tpl.dist
@@ -1,5 +1,5 @@
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     {modifier} function {reference}{method_name}({arguments_decl})
     {
         $arguments = array({arguments_call});

--- a/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator/mocked_static_method.tpl.dist
+++ b/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator/mocked_static_method.tpl.dist
@@ -1,5 +1,5 @@
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     {modifier} static function {reference}{method_name}({arguments_decl})
     {
         $arguments = array({arguments_call});

--- a/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator/wsdl_method.tpl.dist
+++ b/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator/wsdl_method.tpl.dist
@@ -1,5 +1,5 @@
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function {method_name}({arguments})
     {
     }


### PR DESCRIPTION
- use any available version of `symfony/yaml` for wide range of php compatibility (adjustment needed for https://github.com/zf1s/dbunit)
- additionally, use non-namespaced `#[ReturnTypeWillChange]` attribute, as phpunit in the version used here is not namespaced