### PR TITLE
fixes circular dependency issue at zf1s/zf1 when composer2 is used (on windows)

### DIFF
--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -201,7 +201,7 @@ class PHPUnit_Util_GlobalState
         // Do not process bootstrap script - composer v2 compatibility
         // https://github.com/composer/composer/issues/10387#issuecomment-1002942296
         // https://github.com/sebastianbergmann/phpunit/pull/4846
-        while (strpos($files[0], 'bin/phpunit') !== false) {
+        while (strpos($files[0], 'bin' . DIRECTORY_SEPARATOR . 'phpunit') !== false) {
             array_shift($files);
         }
 


### PR DESCRIPTION
followup to #7 - make the fix platform-agnostic (i.e. unstuck `@runInSeparateProcess` tests on windows)