### PR TITLE
Adds PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,17 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "5.3"
-          - "5.4"
-          - "5.5"
-          - "5.6"
-          - "7.0"
           - "7.1"
           - "7.2"
           - "7.3"
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         php_invoker: [true, false]
         coverage: [false]
         experimental: [false]

--- a/PHPUnit/Extensions/PhptTestCase.php
+++ b/PHPUnit/Extensions/PhptTestCase.php
@@ -115,11 +115,11 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
     /**
      * Runs a test and collects its result in a TestResult instance.
      *
-     * @param  PHPUnit_Framework_TestResult $result
+     * @param  ?PHPUnit_Framework_TestResult $result
      * @param  array                        $options
      * @return PHPUnit_Framework_TestResult
      */
-    public function run(PHPUnit_Framework_TestResult $result = NULL, array $options = array())
+    public function run(?PHPUnit_Framework_TestResult $result = NULL, array $options = array())
     {
         if (!class_exists('PEAR_RunTest', FALSE)) {
             throw new PHPUnit_Framework_Exception('Class PEAR_RunTest not found.');

--- a/PHPUnit/Extensions/RepeatedTest.php
+++ b/PHPUnit/Extensions/RepeatedTest.php
@@ -125,11 +125,11 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
      * Runs the decorated test and collects the
      * result in a TestResult.
      *
-     * @param  PHPUnit_Framework_TestResult $result
+     * @param  ?PHPUnit_Framework_TestResult $result
      * @return PHPUnit_Framework_TestResult
      * @throws PHPUnit_Framework_Exception
      */
-    public function run(PHPUnit_Framework_TestResult $result = NULL)
+    public function run(?PHPUnit_Framework_TestResult $result = NULL)
     {
         if ($result === NULL) {
             $result = $this->createResult();

--- a/PHPUnit/Extensions/TestDecorator.php
+++ b/PHPUnit/Extensions/TestDecorator.php
@@ -134,10 +134,10 @@ class PHPUnit_Extensions_TestDecorator extends PHPUnit_Framework_Assert implemen
      * Runs the decorated test and collects the
      * result in a TestResult.
      *
-     * @param  PHPUnit_Framework_TestResult $result
+     * @param  ?PHPUnit_Framework_TestResult $result
      * @return PHPUnit_Framework_TestResult
      */
-    public function run(PHPUnit_Framework_TestResult $result = NULL)
+    public function run(?PHPUnit_Framework_TestResult $result = NULL)
     {
         if ($result === NULL) {
             $result = $this->createResult();

--- a/PHPUnit/Framework/Constraint.php
+++ b/PHPUnit/Framework/Constraint.php
@@ -123,10 +123,10 @@ abstract class PHPUnit_Framework_Constraint implements Countable, PHPUnit_Framew
      *
      * @param  mixed $other Evaluated value or object.
      * @param  string $description Additional information about the test
-     * @param  PHPUnit_Framework_ComparisonFailure $comparisonFailure
+     * @param  ?PHPUnit_Framework_ComparisonFailure $comparisonFailure
      * @throws PHPUnit_Framework_ExpectationFailedException
      */
-    protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+    protected function fail($other, $description, ?PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
     {
         $failureDescription = sprintf(
           'Failed asserting that %s.',

--- a/PHPUnit/Framework/Error.php
+++ b/PHPUnit/Framework/Error.php
@@ -63,9 +63,9 @@ class PHPUnit_Framework_Error extends Exception
      * @param  integer    $code
      * @param  string     $file
      * @param  integer    $line
-     * @param  Exception  $previous
+     * @param  ?Exception  $previous
      */
-    public function __construct($message, $code, $file, $line, Exception $previous = NULL)
+    public function __construct($message, $code, $file, $line, ?Exception $previous = NULL)
     {
         parent::__construct($message, $code, $previous);
 

--- a/PHPUnit/Framework/ExpectationFailedException.php
+++ b/PHPUnit/Framework/ExpectationFailedException.php
@@ -65,7 +65,7 @@ class PHPUnit_Framework_ExpectationFailedException extends PHPUnit_Framework_Ass
      */
     protected $comparisonFailure;
 
-    public function __construct($message, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL, Exception $previous = NULL)
+    public function __construct($message, ?PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL, ?Exception $previous = NULL)
     {
         $this->comparisonFailure = $comparisonFailure;
 

--- a/PHPUnit/Framework/Test.php
+++ b/PHPUnit/Framework/Test.php
@@ -59,8 +59,8 @@ interface PHPUnit_Framework_Test extends Countable
     /**
      * Runs a test and collects its result in a TestResult instance.
      *
-     * @param  PHPUnit_Framework_TestResult $result
+     * @param  ?PHPUnit_Framework_TestResult $result
      * @return PHPUnit_Framework_TestResult
      */
-    public function run(PHPUnit_Framework_TestResult $result = NULL);
+    public function run(?PHPUnit_Framework_TestResult $result = NULL);
 }

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -672,11 +672,11 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      * Runs the test case and collects the results in a TestResult object.
      * If no TestResult object is passed a new one will be created.
      *
-     * @param  PHPUnit_Framework_TestResult $result
+     * @param  ?PHPUnit_Framework_TestResult $result
      * @return PHPUnit_Framework_TestResult
      * @throws PHPUnit_Framework_Exception
      */
-    public function run(PHPUnit_Framework_TestResult $result = NULL)
+    public function run(?PHPUnit_Framework_TestResult $result = NULL)
     {
         if ($result === NULL) {
             $result = $this->createResult();

--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -582,7 +582,7 @@ class PHPUnit_Framework_TestResult implements Countable
         if ($this->convertErrorsToExceptions) {
             $oldErrorHandler = set_error_handler(
               array('PHPUnit_Util_ErrorHandler', 'handleError'),
-              E_ALL | E_STRICT
+              E_ALL
             );
 
             if ($oldErrorHandler === NULL) {

--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -617,7 +617,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     /**
      * Runs the tests and collects their result in a TestResult.
      *
-     * @param  PHPUnit_Framework_TestResult $result
+     * @param  ?PHPUnit_Framework_TestResult $result
      * @param  mixed                        $filter
      * @param  array                        $groups
      * @param  array                        $excludeGroups
@@ -625,7 +625,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      * @return PHPUnit_Framework_TestResult
      * @throws PHPUnit_Framework_Exception
      */
-    public function run(PHPUnit_Framework_TestResult $result = NULL, $filter = FALSE, array $groups = array(), array $excludeGroups = array(), $processIsolation = FALSE)
+    public function run(?PHPUnit_Framework_TestResult $result = NULL, $filter = FALSE, array $groups = array(), array $excludeGroups = array(), $processIsolation = FALSE)
     {
         if ($result === NULL) {
             $result = $this->createResult();

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -82,11 +82,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
     protected static $versionStringPrinted = FALSE;
 
     /**
-     * @param PHPUnit_Runner_TestSuiteLoader $loader
-     * @param PHP_CodeCoverage_Filter        $filter
+     * @param ?PHPUnit_Runner_TestSuiteLoader $loader
+     * @param ?PHP_CodeCoverage_Filter        $filter
      * @since Method available since Release 3.4.0
      */
-    public function __construct(PHPUnit_Runner_TestSuiteLoader $loader = NULL, PHP_CodeCoverage_Filter $filter = NULL)
+    public function __construct(?PHPUnit_Runner_TestSuiteLoader $loader = NULL, ?PHP_CodeCoverage_Filter $filter = NULL)
     {
         if ($filter === NULL) {
             $filter = new PHP_CodeCoverage_Filter;

--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -99,7 +99,7 @@ class PHPUnit_Util_ErrorHandler
             }
         }
 
-        if ($errno == E_NOTICE || $errno == E_USER_NOTICE || $errno == E_STRICT) {
+        if ($errno == E_NOTICE || $errno == E_USER_NOTICE) {
             if (PHPUnit_Framework_Error_Notice::$enabled !== TRUE) {
                 return FALSE;
             }

--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -343,7 +343,7 @@ class PHPUnit_Util_GlobalState
             foreach ($staticAttributes as $name => $value) {
                 $reflector = new ReflectionProperty($className, $name);
                 $reflector->setAccessible(TRUE);
-                $reflector->setValue(unserialize($value));
+                $reflector->setValue(null, unserialize($value));
             }
         }
 

--- a/PHPUnit/Util/PHP.php
+++ b/PHPUnit/Util/PHP.php
@@ -154,12 +154,12 @@ abstract class PHPUnit_Util_PHP
      * Runs a single job (PHP code) using a separate PHP process.
      *
      * @param  string                       $job
-     * @param  PHPUnit_Framework_TestCase   $test
-     * @param  PHPUnit_Framework_TestResult $result
+     * @param  ?PHPUnit_Framework_TestCase   $test
+     * @param  ?PHPUnit_Framework_TestResult $result
      * @return array|null
      * @throws PHPUnit_Framework_Exception
      */
-    public function runJob($job, PHPUnit_Framework_Test $test = NULL, PHPUnit_Framework_TestResult $result = NULL)
+    public function runJob($job, ?PHPUnit_Framework_Test $test = NULL, ?PHPUnit_Framework_TestResult $result = NULL)
     {
         $process = proc_open(
           $this->getPhpBinary(),

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ This version of PHPUnit bases on release 3.7.38 and is adjusted for compatibilit
 The package was created especially for testing https://github.com/zf1s packages.
 
 All credits go to original PHPUnit author and contributors.
+
+### Running tests
+Run all tests:  
+```
+php phpunit.php --color --stop-on-error --stop-on-failure --stop-on-incomplete
+```

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -66,6 +66,7 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPAR
 class Framework_AssertTest extends PHPUnit_Framework_TestCase
 {
     protected $filesDirectory;
+    protected $html;
 
     protected function setUp()
     {

--- a/Tests/_files/DoubleTestCase.php
+++ b/Tests/_files/DoubleTestCase.php
@@ -14,7 +14,7 @@ class DoubleTestCase implements PHPUnit_Framework_Test
         return 2;
     }
 
-    public function run(PHPUnit_Framework_TestResult $result = NULL)
+    public function run(?PHPUnit_Framework_TestResult $result = NULL)
     {
         $result->startTest($this);
 

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,8 @@
     "support": {
         "issues": "https://github.com/zf1s/phpunit/issues"
     },
-    "repositories": [
-        {
-            "type": "pear",
-            "url": "https://pear.php.net"
-        }
-    ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "phpunit/php-text-template": "^1.2.1",
         "phpunit/phpunit-mock-objects": "^1.2.3",
         "phpunit/php-file-iterator": "^1.4.5",
@@ -44,10 +38,8 @@
         "ext-json": "*",
         "ext-pcre": "*",
         "ext-reflection": "*",
-        "ext-spl": "*"
-    },
-    "require-dev": {
-        "pear-pear.php.net/pear": "~1.9|~1.10"
+        "ext-spl": "*",
+        "pear/pear": "^1.10"
     },
     "suggest": {
         "phpunit/php-invoker": "~1.1"


### PR DESCRIPTION
* Adds necessary changes for achieving PHP 8.4 compatibility
* Switches PEAR to github, because PEAR repository was removed and no longer works with composer v2
* Removes PHP 5.3 -> 7.0 compatibility due to lack of syntax that would work for both PHP <= 7.0 and 8.4+
* Removes E_STRICT, which is triggers deprecated error

Edit: This pull request will be split into specific ones.