### PR TITLE
PHP 8.2: Dynamic Properties are deprecated

### DIFF
--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -66,6 +66,7 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPAR
 class Framework_AssertTest extends PHPUnit_Framework_TestCase
 {
     protected $filesDirectory;
+    protected $html;
 
     protected function setUp()
     {


### PR DESCRIPTION
PHP 8.2: Dynamic Properties are deprecated
https://php.watch/versions/8.2/dynamic-properties-deprecated

```
Framework_AssertTest::testFail
Creation of dynamic property Framework_AssertTest::$html is deprecated
```