### PR TITLE
fix implicit nullable in MockObject Generator::generate()

### DIFF
--- a/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator.php
+++ b/deps/phpunit-mock-objects/PHPUnit/Framework/MockObject/Generator.php
@@ -376,8 +376,12 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  boolean $cloneArguments
      * @return array
      */
-    public static function generate($originalClassName, array $methods = NULL, $mockClassName = '', $callOriginalClone = TRUE, $callAutoload = TRUE, $cloneArguments = TRUE)
+    public static function generate($originalClassName, $methods = NULL, $mockClassName = '', $callOriginalClone = TRUE, $callAutoload = TRUE, $cloneArguments = TRUE)
     {
+        if ($methods !== NULL && !is_array($methods)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'array');
+        }
+
         if ($mockClassName == '') {
             $key = md5(
               $originalClassName .


### PR DESCRIPTION
`array $methods = NULL` in `Generator::generate()` triggers deprecation on php 8.4. Missed in the 3.7.44 release because it's in `deps/phpunit-mock-objects` which wasn't included in the nullable parameter fix pass.

Removes the `array` type hint and adds a runtime check, same pattern as the other nullable fixes in PR #25.

Manifests as test failures in consumers (e.g. zf1s/zf1) when any test uses `$this->getMock()` without specifying methods - phpunit's own test suite doesn't exercise this code path on 8.4.